### PR TITLE
[fix][bk] Fix NPE in IsolatedBookieEnsemblePlacementPolicy when ensemble placement policy class does not match

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
@@ -168,7 +168,7 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
 
     private static Pair<Set<String>, Set<String>> getIsolationGroup(
             EnsemblePlacementPolicyConfig ensemblePlacementPolicyConfig) {
-        MutablePair<Set<String>, Set<String>> pair = new MutablePair<>();
+        MutablePair<Set<String>, Set<String>> pair = new MutablePair<>(Collections.emptySet(), Collections.emptySet());
         String className = IsolatedBookieEnsemblePlacementPolicy.class.getName();
         if (ensemblePlacementPolicyConfig.getPolicyClass().getName().equals(className)) {
             Map<String, Object> properties = ensemblePlacementPolicyConfig.getProperties();
@@ -178,13 +178,9 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
                     .castToString(properties.getOrDefault(SECONDARY_ISOLATION_BOOKIE_GROUPS, ""));
             if (!primaryIsolationGroupString.isEmpty()) {
                 pair.setLeft(Sets.newHashSet(primaryIsolationGroupString.split(",")));
-            } else {
-                pair.setLeft(Collections.emptySet());
             }
             if (!secondaryIsolationGroupString.isEmpty()) {
                 pair.setRight(Sets.newHashSet(secondaryIsolationGroupString.split(",")));
-            } else {
-                pair.setRight(Collections.emptySet());
             }
         }
         return pair;


### PR DESCRIPTION
Fixes NPE in `IsolatedBookieEnsemblePlacementPolicy`

### Motivation

A `NullPointerException` occurs in `getExcludedBookiesWithIsolationGroups` when `getIsolationGroup()` returns a `Pair` whose `left` value is `null`. This happens when the `EnsemblePlacementPolicyConfig` carries a policy class name that does not equal `IsolatedBookieEnsemblePlacementPolicy` — in that case the `if` block that calls `pair.setLeft()` / `pair.setRight()` is skipped entirely, leaving both sides of the `MutablePair` as `null`.

The bug was observed in the 3.0 branch and the same defect exists in master.

**Full stack trace from production:**

```
2026-05-18T13:28:40.756Z [BookKeeperClientWorker-OrderedExecutor-35-0] ERROR org.apache.bookkeeper.common.util.SingleThreadExecutor - Error while running task: Cannot invoke "java.util.Set.contains(Object)" because the return value of "org.apache.commons.lang3.tuple.Pair.getLeft()" is null
java.lang.NullPointerException: Cannot invoke "java.util.Set.contains(Object)" because the return value of "org.apache.commons.lang3.tuple.Pair.getLeft()" is null
    at org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy.getExcludedBookiesWithIsolationGroups(IsolatedBookieEnsemblePlacementPolicy.java:192)
    at org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy.getExcludedBookies(IsolatedBookieEnsemblePlacementPolicy.java:141)
    at org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy.replaceBookie(IsolatedBookieEnsemblePlacementPolicy.java:127)
    at org.apache.bookkeeper.client.BookieWatcherImpl.replaceBookie(BookieWatcherImpl.java:316)
    at org.apache.bookkeeper.client.EnsembleUtils.replaceBookiesInEnsemble(EnsembleUtils.java:69)
    at org.apache.bookkeeper.client.ReadOnlyLedgerHandle.handleBookieFailure(ReadOnlyLedgerHandle.java:222)
    at org.apache.bookkeeper.client.PendingAddOp.writeComplete(PendingAddOp.java:353)
    at org.apache.bookkeeper.proto.BookieClientImpl.completeAdd(BookieClientImpl.java:287)
    at org.apache.bookkeeper.proto.BookieClientImpl.access$200(BookieClientImpl.java:79)
    at org.apache.bookkeeper.proto.BookieClientImpl$ChannelReadyForAddEntryCallback.lambda$operationComplete$0(BookieClientImpl.java:405)
    at org.apache.bookkeeper.common.util.OrderedExecutor$TimedRunnable.run(OrderedExecutor.java:203)
    at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:137)
    at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:107)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.base/java.lang.Thread.run(Thread.java:840)
```

### Modifications

Initialize the `MutablePair` in `getIsolationGroup()` with empty sets instead of `null`, so that callers are always guaranteed non-null `left` and `right` values regardless of whether the policy class name matches.

```java
// Before
MutablePair<Set<String>, Set<String>> pair = new MutablePair<>();

// After
MutablePair<Set<String>, Set<String>> pair = new MutablePair<>(Collections.emptySet(), Collections.emptySet());
```

This also implicitly fixes a second latent NPE at line 222–227 where `isolationGroups.getLeft()` could be assigned to `primaryIsolationGroup` and then dereferenced without a null check.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment